### PR TITLE
[#3] ユーザー認証(ユーザー作成画面とログイン画面)を実装しよう

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@hookform/resolvers": "^3.3.1",
     "@tanstack/react-query": "^4.33.0",
     "@testing-library/jest-dom": "^6.1.2",
     "@testing-library/react": "^13.0.0",
@@ -24,7 +25,8 @@
     "react-scripts": "5.0.1",
     "sass": "^1.66.1",
     "sass-loader": "^13.3.2",
-    "web-vitals": "^2.1.0"
+    "web-vitals": "^2.1.0",
+    "yup": "^1.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-hook-form": "^7.46.1",
     "react-router-dom": "^6.16.0",
     "react-scripts": "5.0.1",
+    "react-toastify": "^9.1.3",
     "sass": "^1.66.1",
     "sass-loader": "^13.3.2",
     "web-vitals": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prettier": "^3.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.16.0",
     "react-scripts": "5.0.1",
     "sass": "^1.66.1",
     "sass-loader": "^13.3.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prettier": "^3.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.46.1",
     "react-router-dom": "^6.16.0",
     "react-scripts": "5.0.1",
     "sass": "^1.66.1",
@@ -48,6 +49,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "compressorjs": "^1.2.1",
     "cypress": "^12.17.4"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
-import { Signin } from './Pages/Signin.jsx'
+import { AppRouter } from './routes/Router.jsx'
 import './scss/App.scss'
 
 const queryClient = new QueryClient()
@@ -8,11 +8,7 @@ const queryClient = new QueryClient()
 export const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
-      <div className="App">
-        <header className="App-header">
-          <Signin />
-        </header>
-      </div>
+      <AppRouter />
     </QueryClientProvider>
   )
 }

--- a/src/Components/ToastNotifications.jsx
+++ b/src/Components/ToastNotifications.jsx
@@ -1,0 +1,19 @@
+import { ToastContainer } from 'react-toastify'
+import 'react-toastify/dist/ReactToastify.css'
+
+export const ToastNotifications = () => {
+  return (
+    <ToastContainer
+      position="top-right"
+      autoClose={1500}
+      hideProgressBar={false}
+      newestOnTop={false}
+      closeOnClick
+      rtl={false}
+      pauseOnFocusLoss
+      draggable
+      pauseOnHover
+      theme="light"
+    />
+  )
+}

--- a/src/Pages/NotFound.jsx
+++ b/src/Pages/NotFound.jsx
@@ -1,0 +1,3 @@
+export const NotFound = () => {
+  return <div>ページが見つかりませんでした。</div>
+}

--- a/src/Pages/Signin.jsx
+++ b/src/Pages/Signin.jsx
@@ -58,21 +58,23 @@ export const Signin = () => {
   }
 
   return (
-    <div className="signin">
+    <form className="signin">
       <input
         type="email"
         placeholder="Email"
         value={state.email}
+        autoComplete="username"
         onChange={(e) => dispatch({ type: 'SET_EMAIL', payload: e.target.value })}
       />
       <input
         type="password"
         placeholder="Password"
         value={state.password}
+        autoComplete="current-password"
         onChange={(e) => dispatch({ type: 'SET_PASSWORD', payload: e.target.value })}
       />
       <button onClick={handleSubmit}>Login</button>
       {state.errorMessage && <p className="error-message">{state.errorMessage}</p>}
-    </div>
+    </form>
   )
 }

--- a/src/Pages/Signup.jsx
+++ b/src/Pages/Signup.jsx
@@ -1,14 +1,62 @@
+import { useState } from 'react'
+
+import { URL } from '../const'
 import '../scss/signup.scss'
 
+const createUser = async (name, email, password) => {
+  const response = await fetch(`${URL}/users`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      name,
+      email,
+      password,
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error('User creation failed')
+  }
+
+  return response.json()
+}
+
 export const Signup = () => {
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [errors, setErrors] = useState([])
+  const [debugToken, setDebugToken] = useState('') // <-- Add this state
+
+  const handleSignup = async () => {
+    try {
+      const userResponse = await createUser(name, email, password)
+      localStorage.setItem('token', userResponse.token)
+      setDebugToken(userResponse.token) // <-- Set the token to the state
+    } catch (error) {
+      console.error(error)
+      setErrors((prev) => [...prev, '登録中にエラーが発生しました。'])
+    }
+  }
+
   return (
     <div className="signup">
-      <div data-testid="image-preview"></div>
       <input type="file" aria-label="画像を追加" />
-      <input type="text" placeholder="名前" />
-      <input type="text" placeholder="Email" />
-      <input type="password" placeholder="Password" />
-      <button>登録</button>
+      <input type="text" placeholder="名前" onChange={(e) => setName(e.target.value)} />
+      <input type="text" placeholder="Email" onChange={(e) => setEmail(e.target.value)} />
+      <input type="password" placeholder="Password" onChange={(e) => setPassword(e.target.value)} />
+      <button onClick={handleSignup}>登録</button>
+      {debugToken && <div className="debug-token">Token: {debugToken}</div>}
+      {errors.map((error, index) => (
+        <div key={index} className="error">
+          {error}
+        </div>
+      ))}
+      <div className="login-link">
+        既にアカウントをお持ちですか？<a href="/login">ログイン</a>
+      </div>
     </div>
   )
 }

--- a/src/Pages/Signup.jsx
+++ b/src/Pages/Signup.jsx
@@ -1,0 +1,14 @@
+import '../scss/signup.scss'
+
+export const Signup = () => {
+  return (
+    <div className="signup">
+      <div data-testid="image-preview"></div>
+      <input type="file" aria-label="画像を追加" />
+      <input type="text" placeholder="名前" />
+      <input type="text" placeholder="Email" />
+      <input type="password" placeholder="Password" />
+      <button>登録</button>
+    </div>
+  )
+}

--- a/src/Pages/Signup.jsx
+++ b/src/Pages/Signup.jsx
@@ -23,11 +23,37 @@ const createUser = async (name, email, password) => {
   return response.json()
 }
 
+const uploadImage = async (file, token) => {
+  console.log('Upload function called with token:', token)
+  console.log('File to upload:', file)
+
+  const formData = new FormData()
+  formData.append('icon', file)
+
+  const response = await fetch(`${URL}/uploads`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    body: formData,
+  })
+
+  if (!response.ok) {
+    throw new Error('Image upload failed')
+  }
+
+  console.log('Server response:', response)
+  console.log('Server response status:', response.status)
+
+  return response.json()
+}
+
 export const Signup = () => {
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [errors, setErrors] = useState([])
+  const [file, setFile] = useState(null)
   const [debugToken, setDebugToken] = useState('') // <-- Add this state
 
   const handleSignup = async () => {
@@ -35,6 +61,11 @@ export const Signup = () => {
       const userResponse = await createUser(name, email, password)
       localStorage.setItem('token', userResponse.token)
       setDebugToken(userResponse.token) // <-- Set the token to the state
+
+      // トークン取得後に画像をアップロードする
+      if (file) {
+        await uploadImage(file, userResponse.token)
+      }
     } catch (error) {
       console.error(error)
       setErrors((prev) => [...prev, '登録中にエラーが発生しました。'])
@@ -43,7 +74,7 @@ export const Signup = () => {
 
   return (
     <div className="signup">
-      <input type="file" aria-label="画像を追加" />
+      <input type="file" aria-label="画像を追加" onChange={(e) => setFile(e.target.files[0])} />
       <input type="text" placeholder="名前" onChange={(e) => setName(e.target.value)} />
       <input type="text" placeholder="Email" onChange={(e) => setEmail(e.target.value)} />
       <input type="password" placeholder="Password" onChange={(e) => setPassword(e.target.value)} />

--- a/src/Pages/Signup.jsx
+++ b/src/Pages/Signup.jsx
@@ -130,19 +130,19 @@ export const Signup = () => {
   }
 
   return (
-    <div className="signup">
+    <form className="signup">
       {errors.name && <div className="error">{errors.name.message}</div>}
       {errors.email && <div className="error">{errors.email.message}</div>}
       {errors.password && <div className="error">{errors.password.message}</div>}
       {showModal ? <Modal resizedImageBlob={resizedImageBlob} closeModal={closeModal} /> : null}
       <input key={inputKey} type="file" aria-label="画像を追加" onChange={handleFileChange} />
       <input type="text" placeholder="名前" {...register('name')} />
-      <input type="text" placeholder="Email" {...register('email')} />
-      <input type="password" placeholder="Password" {...register('password')} />
+      <input type="text" placeholder="Email" {...register('email')} autoComplete="username" />
+      <input type="password" placeholder="Password" {...register('password')} autoComplete="current-password" />
       <button onClick={handleSubmit(onSubmit)}>登録</button>
       <div className="login-link">
         既にアカウントをお持ちですか？<a href="/login">ログイン</a>
       </div>
-    </div>
+    </form>
   )
 }

--- a/src/Pages/Signup.jsx
+++ b/src/Pages/Signup.jsx
@@ -8,20 +8,15 @@ import { toast } from 'react-toastify'
 import * as yup from 'yup'
 
 import { ToastNotifications } from '../Components/ToastNotifications.jsx'
-import { URL as API_URL, SUCCESS_MESSAGE, ERROR_MESSAGE } from '../const'
+import { URL as API_URL, SUCCESS_MESSAGE, ERROR_MESSAGE, NAME_REGEX } from '../const'
 import '../scss/signup.scss'
 
-const FULL_WIDTH_SPACE = '\u3000'
 const schema = yup.object().shape({
   name: yup
     .string()
     .required('名前は必須です。')
     .max(30, '名前は30文字以下にしてください。')
-    .notOneOf([' ', FULL_WIDTH_SPACE], '名前に空白文字のみは使えません。')
-    .matches(
-      new RegExp(`^[^\\s${FULL_WIDTH_SPACE}].*[^\\s${FULL_WIDTH_SPACE}]$`),
-      '名前の前後に空白文字は使用できません。'
-    ),
+    .matches(NAME_REGEX, '名前に記号は使えません。'),
   email: yup.string().required('メールアドレスは必須です。').email('無効なメールアドレスの形式です。'),
   password: yup
     .string()
@@ -118,7 +113,6 @@ export const Signup = () => {
       if (file) {
         await uploadImage(file, userResponse.token)
       }
-
       toast.success(SUCCESS_MESSAGE)
       closeModal()
       reset({ name: '', email: '', password: '' })

--- a/src/Pages/Signup.jsx
+++ b/src/Pages/Signup.jsx
@@ -6,8 +6,12 @@ import { useForm } from 'react-hook-form'
 import { URL as API_URL } from '../const'
 import '../scss/signup.scss'
 
-const PASSWORD_PATTERN = '/^[A-Za-z0-9!"#$%&\'()-^@[];:,./=|~+*{}<>?_]+$/'
-const EMAIL_PATTERN = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i
+const PASSWORD_PATTERN = /^[A-Za-z0-9]+$/
+const EMAIL_PATTERN = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,6}$/i
+// eslint-disable-next-line no-irregular-whitespace
+const isOnlyWhitespace = (str) => /^[\s　]+$/.test(str)
+// eslint-disable-next-line no-irregular-whitespace
+const hasLeadingOrTrailingWhitespace = (str) => /^[\s　]+|[\s　]+$/.test(str)
 
 const postUserData = async (url, body) => {
   const response = await fetch(url, {
@@ -60,7 +64,7 @@ export const Signup = () => {
     if (selectedFile) {
       // eslint-disable-next-line no-new
       new Compressor(selectedFile, {
-        quality: 0.6, // 60%の画質で圧縮する
+        quality: 0.6,
         success(result) {
           setResizedImageBlob(result)
           setShowModal(true)
@@ -110,9 +114,24 @@ export const Signup = () => {
 
   return (
     <div className="signup">
+      {errors.name && <div className="error">{errors.name.message}</div>}
+      {errors.email && <div className="error">{errors.email.message}</div>}
+      {errors.password && <div className="error">{errors.password.message}</div>}
       {showModal ? <Modal resizedImageBlob={resizedImageBlob} closeModal={closeModal} /> : null}
       <input key={inputKey} type="file" aria-label="画像を追加" onChange={handleFileChange} />
-      <input type="text" placeholder="名前" {...register('name', { required: '名前は必須です。' })} />
+      <input
+        type="text"
+        placeholder="名前"
+        {...register('name', {
+          required: '名前は必須です。',
+          maxLength: { value: 30, message: '名前は30文字以下にしてください。' },
+          validate: {
+            notOnlyWhitespace: (value) => !isOnlyWhitespace(value) || '名前に空白文字のみは使えません。',
+            noLeadingOrTrailingWhitespace: (value) =>
+              !hasLeadingOrTrailingWhitespace(value) || '名前の前後に空白文字は使用できません。',
+          },
+        })}
+      />
       <input
         type="text"
         placeholder="Email"
@@ -124,23 +143,19 @@ export const Signup = () => {
           },
         })}
       />
-
       <input
         type="password"
         placeholder="Password"
         {...register('password', {
           required: 'パスワードは必須です。',
-          minLength: { value: 12, message: 'パスワードは12文字以上である必要があります。' },
+          minLength: { value: 12, message: 'パスワードは12文字以上にしてください。' },
+          maxLength: { value: 30, message: 'パスワードは30文字以下にしてください。' },
           pattern: {
             value: PASSWORD_PATTERN,
-            message: 'パスワードには、半角英数字記号のみ使用できます。',
+            message: 'パスワードは半角英数字のみ使用できます。',
           },
         })}
       />
-      {errors.name && <div className="error">{errors.name.message}</div>}
-      {errors.email && <div className="error">{errors.email.message}</div>}
-      {errors.password && <div className="error">{errors.password.message}</div>}
-
       <button onClick={handleSubmit(onSubmit)}>登録</button>
       <div className="login-link">
         既にアカウントをお持ちですか？<a href="/login">ログイン</a>

--- a/src/Pages/Signup.jsx
+++ b/src/Pages/Signup.jsx
@@ -131,9 +131,9 @@ export const Signup = () => {
 
   return (
     <form className="signup">
-      {errors.name && <div className="error">{errors.name.message}</div>}
-      {errors.email && <div className="error">{errors.email.message}</div>}
-      {errors.password && <div className="error">{errors.password.message}</div>}
+      {errors.name && <div className="error-message">{errors.name.message}</div>}
+      {errors.email && <div className="error-message">{errors.email.message}</div>}
+      {errors.password && <div className="error-message">{errors.password.message}</div>}
       {showModal ? <Modal resizedImageBlob={resizedImageBlob} closeModal={closeModal} /> : null}
       <input key={inputKey} type="file" aria-label="画像を追加" onChange={handleFileChange} />
       <input type="text" placeholder="名前" {...register('name')} />

--- a/src/Pages/Signup.jsx
+++ b/src/Pages/Signup.jsx
@@ -3,6 +3,7 @@ import Compressor from 'compressorjs'
 import PropTypes from 'prop-types'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
+import { Link } from 'react-router-dom'
 import * as yup from 'yup'
 
 import { URL as API_URL } from '../const'
@@ -141,7 +142,7 @@ export const Signup = () => {
       <input type="password" placeholder="Password" {...register('password')} autoComplete="current-password" />
       <button onClick={handleSubmit(onSubmit)}>登録</button>
       <div className="login-link">
-        既にアカウントをお持ちですか？<a href="/login">ログイン</a>
+        既にアカウントをお持ちですか？<Link to="/login">ログイン</Link>
       </div>
     </form>
   )

--- a/src/__tests__/Notfound.test.js
+++ b/src/__tests__/Notfound.test.js
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+import { NotFound } from '../Pages/NotFound.jsx'
+import { Signup } from '../Pages/Signup.jsx'
+
+describe('Routing', () => {
+  it('存在しないルートにアクセスした場合、メッセージが表示される。', () => {
+    render(
+      <MemoryRouter initialEntries={['/non-existent-route']}>
+        <Routes>
+          <Route path="/non-existent-route" element={<NotFound />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('ページが見つかりませんでした。')).toBeInTheDocument()
+  })
+
+  it('存在するルートにアクセスした場合、メッセージが表示されない。', () => {
+    render(
+      <MemoryRouter initialEntries={['/signup']}>
+        <Routes>
+          <Route path="/signup" element={<Signup />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    // "ページが見つかりませんでした。" がDOMに存在しないことを確認する
+    expect(screen.queryByText('ページが見つかりませんでした。')).toBeNull()
+  })
+})

--- a/src/__tests__/Signup.test.js
+++ b/src/__tests__/Signup.test.js
@@ -1,10 +1,15 @@
 import { render, screen } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
 
 import { Signup } from '../Pages/Signup.jsx'
 
 describe('Signup', () => {
   it('ログイン画面に必要なコンポーネントが存在する', () => {
-    render(<Signup />)
+    render(
+      <BrowserRouter>
+        <Signup />
+      </BrowserRouter>
+    )
 
     // 入力フォームが存在するか確認
     expect(screen.getByPlaceholderText('名前')).toBeInTheDocument()

--- a/src/__tests__/Signup.test.js
+++ b/src/__tests__/Signup.test.js
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+
+import { Signup } from '../Pages/Signup.jsx'
+
+describe('Signin', () => {
+  it('ログイン画面に必要なコンポーネントが存在する', () => {
+    render(<Signup />)
+
+    // 入力フォームが存在するか確認
+    expect(screen.getByPlaceholderText('名前')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Email')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Password')).toBeInTheDocument()
+
+    // ボタンが存在するか確認
+    expect(screen.getByText('登録')).toBeInTheDocument()
+
+    expect(screen.getByLabelText('画像を追加')).toBeInTheDocument()
+    expect(screen.getByTestId('image-preview')).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/Signup.test.js
+++ b/src/__tests__/Signup.test.js
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 
 import { Signup } from '../Pages/Signup.jsx'
 
-describe('Signin', () => {
+describe('Signup', () => {
   it('ログイン画面に必要なコンポーネントが存在する', () => {
     render(<Signup />)
 
@@ -15,6 +15,5 @@ describe('Signin', () => {
     expect(screen.getByText('登録')).toBeInTheDocument()
 
     expect(screen.getByLabelText('画像を追加')).toBeInTheDocument()
-    expect(screen.getByTestId('image-preview')).toBeInTheDocument()
   })
 })

--- a/src/const.js
+++ b/src/const.js
@@ -1,3 +1,16 @@
 export const URL = process.env.REACT_APP_BASEURL
 export const SUCCESS_MESSAGE = '登録が成功しました。'
 export const ERROR_MESSAGE = 'エラーが発生しました。後でもう一度お試しください。'
+
+// 各文字範囲の定義
+const KANJI = '\u4e00-\u9faf'
+const HIRAGANA = '\u3040-\u309f'
+const KATAKANA = '\u30a0-\u30ff'
+const HALFWIDTH_ENGLISH = 'a-zA-Z'
+const HALFWIDTH_NUMBERS = '0-9'
+const FULLWIDTH_ENGLISH = '\uff21-\uff3a\uff41-\uff5a'
+
+// 組み合わせた正規表現
+export const NAME_REGEX = new RegExp(
+  `^[${KANJI}${HIRAGANA}${KATAKANA}${HALFWIDTH_ENGLISH}${HALFWIDTH_NUMBERS}${FULLWIDTH_ENGLISH}]+$`
+)

--- a/src/const.js
+++ b/src/const.js
@@ -1,1 +1,3 @@
 export const URL = process.env.REACT_APP_BASEURL
+export const SUCCESS_MESSAGE = '登録が成功しました。'
+export const ERROR_MESSAGE = 'エラーが発生しました。後でもう一度お試しください。'

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -1,0 +1,19 @@
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
+
+import { Signin } from '../Pages/Signin.jsx'
+
+export const AppRouter = () => {
+  return (
+    <Router>
+      <div className="App">
+        <header className="App-header">
+          <Signin />
+          <Routes>
+            <Route path="/login" element={<Signin />} />
+            <Route path="/" element={<Navigate to="/signin" />} />
+          </Routes>
+        </header>
+      </div>
+    </Router>
+  )
+}

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -1,19 +1,32 @@
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
+import { BrowserRouter as Router, Routes, Route, Navigate, Link, useLocation } from 'react-router-dom'
 
 import { Signin } from '../Pages/Signin.jsx'
+import { Signup } from '../Pages/Signup.jsx'
 
 export const AppRouter = () => {
   return (
     <Router>
       <div className="App">
         <header className="App-header">
-          <Signin />
-          <Routes>
-            <Route path="/login" element={<Signin />} />
-            <Route path="/" element={<Navigate to="/signin" />} />
-          </Routes>
+          <RoutesWithLinks />
         </header>
       </div>
     </Router>
+  )
+}
+
+const RoutesWithLinks = () => {
+  // 現在のルート（URL）を取得する
+  const location = useLocation()
+
+  return (
+    <>
+      <Routes>
+        <Route path="/" element={<Navigate to="/login" />} />
+        <Route path="/login" element={<Signin />} />
+        <Route path="/signup" element={<Signup />} />
+      </Routes>
+      {location.pathname === '/login' && <Link to="/signup">登録はこちらから</Link>}
+    </>
   )
 }

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -1,5 +1,6 @@
 import { BrowserRouter as Router, Routes, Route, Navigate, Link, useLocation } from 'react-router-dom'
 
+import { NotFound } from '../Pages/NotFound.jsx'
 import { Signin } from '../Pages/Signin.jsx'
 import { Signup } from '../Pages/Signup.jsx'
 
@@ -25,6 +26,7 @@ const RoutesWithLinks = () => {
         <Route path="/" element={<Navigate to="/login" />} />
         <Route path="/login" element={<Signin />} />
         <Route path="/signup" element={<Signup />} />
+        <Route path="*" element={<NotFound />} />
       </Routes>
       {location.pathname === '/login' && <Link to="/signup">登録はこちらから</Link>}
     </>

--- a/src/scss/App.scss
+++ b/src/scss/App.scss
@@ -36,3 +36,10 @@
     transform: rotate(360deg);
   }
 }
+
+.error-message {
+  color: red;
+  font-size: 20px;
+  margin-top: 8px;
+  margin-bottom: 8px;
+}

--- a/src/scss/signup.scss
+++ b/src/scss/signup.scss
@@ -1,0 +1,5 @@
+.signup {
+  display: flex;
+  flex-direction: column;
+  gap: 10px; // 各要素の間にスペースを追加
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3678,6 +3678,11 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
+clsx@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
@@ -9397,6 +9402,13 @@ react-scripts@5.0.1:
     workbox-webpack-plugin "^6.4.1"
   optionalDependencies:
     fsevents "^2.3.2"
+
+react-toastify@^9.1.3:
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-9.1.3.tgz#1e798d260d606f50e0fab5ee31daaae1d628c5ff"
+  integrity sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==
+  dependencies:
+    clsx "^1.1.1"
 
 react@^18.2.0:
   version "18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1403,6 +1403,11 @@
   resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
+"@hookform/resolvers@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-3.3.1.tgz#b7cbfe767434f52cba6b99b0a9a0b73eb8895188"
+  integrity sha512-K7KCKRKjymxIB90nHDQ7b9nli474ru99ZbqxiqDAWYsYhOsU3/4qLxW91y+1n04ic13ajjZ66L3aXbNef8PELQ==
+
 "@humanwhocodes/config-array@^0.11.10":
   version "0.11.10"
   resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz"
@@ -9144,6 +9149,11 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+property-expr@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
+  integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
+
 proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz"
@@ -10677,6 +10687,11 @@ thunky@^1.0.2:
   resolved "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
+tiny-case@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
+  integrity sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==
+
 titleize@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz"
@@ -10710,6 +10725,11 @@ toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
 
 tough-cookie@^4.0.0, tough-cookie@^4.1.3:
   version "4.1.3"
@@ -10835,6 +10855,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 type-is@~1.6.18:
   version "1.6.18"
@@ -11675,3 +11700,13 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yup@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.2.0.tgz#9e51af0c63bdfc9be0fdc6c10aa0710899d8aff6"
+  integrity sha512-PPqYKSAXjpRCgLgLKVGPA33v5c/WgEx3wi6NFjIiegz90zSwyMpvTFp/uGcVnnbx6to28pgnzp/q8ih3QRjLMQ==
+  dependencies:
+    property-expr "^2.0.5"
+    tiny-case "^1.0.3"
+    toposort "^2.0.2"
+    type-fest "^2.19.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1780,6 +1780,11 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
+"@remix-run/router@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.9.0.tgz#9033238b41c4cbe1e961eccb3f79e2c588328cf6"
+  integrity sha512-bV63itrKBC0zdT27qYm6SDZHlkXwFL1xMBuhkn+X7l0+IIhNaH5wuuvZKp6eKhCD4KFhujhfhCT1YxXW6esUIA==
+
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
   resolved "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz"
@@ -9289,6 +9294,21 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-router-dom@^6.16.0:
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.16.0.tgz#86f24658da35eb66727e75ecbb1a029e33ee39d9"
+  integrity sha512-aTfBLv3mk/gaKLxgRDUPbPw+s4Y/O+ma3rEN1u8EgEpLpPe6gNjIsWt9rxushMHHMb7mSwxRGdGlGdvmFsyPIg==
+  dependencies:
+    "@remix-run/router" "1.9.0"
+    react-router "6.16.0"
+
+react-router@6.16.0:
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.16.0.tgz#abbf3d5bdc9c108c9b822a18be10ee004096fb81"
+  integrity sha512-VT4Mmc4jj5YyjpOi5jOf0I+TYzGpvzERy4ckNSvSh2RArv8LLoCxlsZ2D+tc7zgjxcY34oTz2hZaeX5RVprKqA==
+  dependencies:
+    "@remix-run/router" "1.9.0"
 
 react-scripts@5.0.1:
   version "5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3264,6 +3264,11 @@ bluebird@^3.5.5, bluebird@^3.7.2:
   resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
+blueimp-canvas-to-blob@^3.29.0:
+  version "3.29.0"
+  resolved "https://registry.yarnpkg.com/blueimp-canvas-to-blob/-/blueimp-canvas-to-blob-3.29.0.tgz#d965f06cb1a67fdae207a2be56683f55ef531466"
+  integrity sha512-0pcSSGxC0QxT+yVkivxIqW0Y4VlO2XSDPofBAqoJ1qJxgH9eiUDLv50Rixij2cDuEfx4M6DpD9UGZpRhT5Q8qg==
+
 body-parser@1.20.1:
   version "1.20.1"
   resolved "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz"
@@ -3792,6 +3797,14 @@ compression@^1.7.4:
     on-headers "~1.0.2"
     safe-buffer "5.1.2"
     vary "~1.1.2"
+
+compressorjs@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/compressorjs/-/compressorjs-1.2.1.tgz#4dee18ef5032f8166bd0a3258f045eda2cd07671"
+  integrity sha512-+geIjeRnPhQ+LLvvA7wxBQE5ddeLU7pJ3FsKFWirDw6veY3s9iLxAQEw7lXGHnhCJvBujEQWuNnGzZcvCvdkLQ==
+  dependencies:
+    blueimp-canvas-to-blob "^3.29.0"
+    is-blob "^2.1.0"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -6266,6 +6279,11 @@ is-binary-path@~2.1.0:
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
+
+is-blob@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-blob/-/is-blob-2.1.0.tgz#e36cd82c90653f1e1b930f11baf9c64216a05385"
+  integrity sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==
 
 is-boolean-object@^1.1.0:
   version "1.1.2"
@@ -9274,6 +9292,11 @@ react-error-overlay@^6.0.11:
   version "6.0.11"
   resolved "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
+
+react-hook-form@^7.46.1:
+  version "7.46.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.46.1.tgz#39347dbff19d980cb41087ac32a57abdc6045bb3"
+  integrity sha512-0GfI31LRTBd5tqbXMGXT1Rdsv3rnvy0FjEk8Gn9/4tp6+s77T7DPZuGEpBRXOauL+NhyGT5iaXzdIM2R6F/E+w==
 
 react-is@^16.13.1:
   version "16.13.1"


### PR DESCRIPTION

1. **ユーザー情報作成APIを使って、ユーザー作成画面を作成する**    
    - `createUser` 関数でユーザー情報をAPIにPOST
    - `Signup` コンポーネント内でこの関数を `onSubmit` ハンドラー内で呼び出し

2. **ユーザアイコンも登録できるようにする**    
    - `handleFileChange` でファイルを選択した際に、Compressor.js を使って画像をリサイズ
    - その後、ユーザーがフォームを送信、`uploadImage` 関数で画像をAPIにアップロード

3. **写真のリサイズ**    
    - `handleFileChange` 関数内で、Compressor.js を使用
    - 選択されたファイルの画質を0.6に設定してリサイズ

4. **ログイン画面へのリンクを配置する**    
    - サインアップ画面でログイン画面へのリンクを表示されています
    -  `<Link to="/login">ログイン</Link>` で、react-router-dom の Link コンポーネントを使用

5. **エラー時のUIも実装するようにしましょう**    
    - バリデーションエラーに関しては、`react-hook-form` の `errors` オブジェクトを使ってエラーメッセージを表示しています。しかし、API通信のエラーに関しては、`console.error` でのみ表示され、UI上には表示されていません。ユーザーフレンドリーなエラーメッセージをUIに表示するための追加実装が必要です。

6. **バリデーションを実装する**    
    - yupライブラリを使用して、名前、メールアドレス、パスワードのバリデーションルールが定義
    - `react-hook-form` の `register` 関数と組み合わせて、各入力フィールドにバリデーションを適用
